### PR TITLE
ユーザー詳細画面を実装

### DIFF
--- a/FluxGithubApp/FluxGithubApp/Common/Extentions/NSObject+Extention.swift
+++ b/FluxGithubApp/FluxGithubApp/Common/Extentions/NSObject+Extention.swift
@@ -1,0 +1,25 @@
+//
+//  NSObject+Extention.swift
+//  FluxGithubApp
+//
+//  Created by Takahashi Shiko on 2022/04/24.
+//
+
+import Foundation
+
+protocol ClassNameProtocol {
+    static var className: String { get }
+    var className: String { get }
+}
+
+extension ClassNameProtocol {
+    static var className: String {
+        String(describing: self)
+    }
+
+    var className: String {
+        Self.className
+    }
+}
+
+extension NSObject: ClassNameProtocol {}

--- a/FluxGithubApp/FluxGithubApp/Common/Extentions/ViewController+Extention.swift
+++ b/FluxGithubApp/FluxGithubApp/Common/Extentions/ViewController+Extention.swift
@@ -1,0 +1,19 @@
+//
+//  ViewController+Extention.swift
+//  FluxGithubApp
+//
+//  Created by Takahashi Shiko on 2022/04/24.
+//
+
+import Foundation
+import UIKit
+
+protocol StoryBoardHelper {}
+
+extension StoryBoardHelper where Self: UIViewController {
+    static func instantiate() -> Self {
+        // Storyboardの命名はviewController名から”ViewController”を除いたものにしているため、不要な文字を除去する
+        let storyboardName = (self.className).replacingOccurrences(of: "ViewController", with: "")
+        return UIStoryboard(name: storyboardName, bundle: nil).instantiateInitialViewController() as! Self
+    }
+}

--- a/FluxGithubApp/FluxGithubApp/Common/Extentions/ViewController+Extention.swift
+++ b/FluxGithubApp/FluxGithubApp/Common/Extentions/ViewController+Extention.swift
@@ -8,12 +8,14 @@
 import Foundation
 import UIKit
 
-protocol StoryBoardHelper {}
+protocol StoryBoardHelperProtocol {}
 
-extension StoryBoardHelper where Self: UIViewController {
+extension StoryBoardHelperProtocol where Self: UIViewController {
     static func instantiate() -> Self {
         // Storyboardの命名はviewController名から”ViewController”を除いたものにしているため、不要な文字を除去する
         let storyboardName = (self.className).replacingOccurrences(of: "ViewController", with: "")
         return UIStoryboard(name: storyboardName, bundle: nil).instantiateInitialViewController() as! Self
     }
 }
+
+extension UIViewController: StoryBoardHelperProtocol {}

--- a/FluxGithubApp/FluxGithubApp/DI/SwinjectStoryboard.swift
+++ b/FluxGithubApp/FluxGithubApp/DI/SwinjectStoryboard.swift
@@ -33,9 +33,22 @@ extension SwinjectStoryboard {
         }
         .inObjectScope(.container)
         
+        defaultContainer.register(UserDetailStore.self) { r in
+            UserDetailStore(r.resolve(Dispatcher.self)!)
+        }
+        .inObjectScope(.container)
+        
         // ActionCreator
         defaultContainer.register(UserListActionCreator.self) { r in
             UserListActionCreator(
+                r.resolve(Dispatcher.self)!,
+                userRepository: r.resolve(UserRepository.self)!
+            )
+        }
+        .inObjectScope(.container)
+        
+        defaultContainer.register(UserDetailActionCreator.self) { r in
+            UserDetailActionCreator(
                 r.resolve(Dispatcher.self)!,
                 userRepository: r.resolve(UserRepository.self)!
             )
@@ -49,12 +62,23 @@ extension SwinjectStoryboard {
                 store: r.resolve(UserListStore.self)!
             )
         }
-        .inObjectScope(.container)
+        
+        defaultContainer.register(UserDetailViewModel.self) { r in
+            UserDetailViewModel(
+                actionCreator: r.resolve(UserDetailActionCreator.self)!,
+                store: r.resolve(UserDetailStore.self)!
+            )
+        }
         
         // ViewController
         defaultContainer.storyboardInitCompleted(UserListViewController.self) { r, c in
             c.viewModelInput = r.resolve(UserListViewModel.self)
             c.viewModelOutput = r.resolve(UserListViewModel.self)
+        }
+        
+        defaultContainer.storyboardInitCompleted(UserDetailViewController.self) { r, c in
+            c.viewModelInput = r.resolve(UserDetailViewModel.self)
+            c.viewModelOutput = r.resolve(UserDetailViewModel.self)
         }
     }
 }

--- a/FluxGithubApp/FluxGithubApp/DI/SwinjectStoryboard.swift
+++ b/FluxGithubApp/FluxGithubApp/DI/SwinjectStoryboard.swift
@@ -21,6 +21,11 @@ extension SwinjectStoryboard {
         }
         .inObjectScope(.container)
         
+        defaultContainer.register(ReposRepository.self) { r in
+            ReposRepositoryImpl(apiClient: r.resolve(ApiClient.self)!)
+        }
+        .inObjectScope(.container)
+        
         // Dispatch
         defaultContainer.register(Dispatcher.self) { _ in
             Dispatcher.shared
@@ -50,7 +55,8 @@ extension SwinjectStoryboard {
         defaultContainer.register(UserDetailActionCreator.self) { r in
             UserDetailActionCreator(
                 r.resolve(Dispatcher.self)!,
-                userRepository: r.resolve(UserRepository.self)!
+                userRepository: r.resolve(UserRepository.self)!,
+                reposRepository: r.resolve(ReposRepository.self)!
             )
         }
         .inObjectScope(.container)

--- a/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailAction.swift
+++ b/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailAction.swift
@@ -10,9 +10,25 @@ enum UserDetailAction {
         var user: UserDetail
     }
     
-    struct FirstFetchStart: Action { }
+    struct ReposListFirstFetched: Action {
+        var page: Int
+        var reposList: [Repos]
+        var isDataEnded: Bool
+    }
     
-    struct FirstFetchEnd: Action { }
+    struct ReposListMoreFetched: Action {
+        var page: Int
+        var reposList: [Repos]
+        var isDataEnded: Bool
+    }
+    
+    struct UserDetailFetchStart: Action { }
+    
+    struct UserDetailFetchEnd: Action { }
+    
+    struct ReposListFetchStart: Action { }
+    
+    struct ReposListFetchEnd: Action { }
     
     struct ApiError: Action {
         var error: Error

--- a/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailAction.swift
+++ b/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailAction.swift
@@ -1,0 +1,21 @@
+//
+//  UserDetailAction.swift
+//  FluxGithubApp
+//
+//  Created by Takahashi Shiko on 2022/04/24.
+//
+
+enum UserDetailAction {
+    struct UserDetailFetched: Action {
+        var user: UserDetail
+    }
+    
+    struct FirstFetchStart: Action { }
+    
+    struct FirstFetchEnd: Action { }
+    
+    struct ApiError: Action {
+        var error: Error
+    }
+}
+

--- a/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailActionCreator.swift
+++ b/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailActionCreator.swift
@@ -1,0 +1,43 @@
+//
+//  UserDetailActionCreator.swift
+//  FluxGithubApp
+//
+//  Created by Takahashi Shiko on 2022/04/24.
+//
+
+import RxSwift
+
+final class UserDetailActionCreator: ActionCreator {
+    private var userRepository: UserRepository
+    
+    required init(_ dispatcher: Dispatcher, userRepository: UserRepository) {
+        self.userRepository = userRepository
+        super.init(dispatcher)
+    }
+    
+    func fetchUserDetail(username: String) {
+        // 読み込み開始
+        dispatch(UserDetailAction.FirstFetchStart())
+        
+        userRepository.fetchDetail(username: username)
+            .subscribe(with: self, onSuccess: { owner, user in
+                // 読み込み終了
+                owner.dispatch(UserDetailAction.FirstFetchEnd())
+                
+                owner.dispatch(UserDetailAction.UserDetailFetched(
+                    user: user
+                ))
+                
+            }, onFailure: { owner, error in
+                // 読み込み終了
+                owner.dispatch(UserDetailAction.FirstFetchEnd())
+                
+                owner.dispatch(UserDetailAction.ApiError(
+                    error: error
+                ))
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    // TODO: Reposを取得するアクションを追加する
+}

--- a/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailActionCreator.swift
+++ b/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailActionCreator.swift
@@ -9,28 +9,34 @@ import RxSwift
 
 final class UserDetailActionCreator: ActionCreator {
     private var userRepository: UserRepository
+    private var reposRepository: ReposRepository
     
-    required init(_ dispatcher: Dispatcher, userRepository: UserRepository) {
+    required init(
+        _ dispatcher: Dispatcher,
+        userRepository: UserRepository,
+        reposRepository: ReposRepository
+    ) {
         self.userRepository = userRepository
+        self.reposRepository = reposRepository
         super.init(dispatcher)
     }
     
+    /// ユーザー詳細情報を取得
     func fetchUserDetail(username: String) {
         // 読み込み開始
-        dispatch(UserDetailAction.FirstFetchStart())
+        dispatch(UserDetailAction.UserDetailFetchStart())
         
         userRepository.fetchDetail(username: username)
             .subscribe(with: self, onSuccess: { owner, user in
                 // 読み込み終了
-                owner.dispatch(UserDetailAction.FirstFetchEnd())
+                owner.dispatch(UserDetailAction.UserDetailFetchEnd())
                 
                 owner.dispatch(UserDetailAction.UserDetailFetched(
                     user: user
                 ))
-                
             }, onFailure: { owner, error in
                 // 読み込み終了
-                owner.dispatch(UserDetailAction.FirstFetchEnd())
+                owner.dispatch(UserDetailAction.UserDetailFetchEnd())
                 
                 owner.dispatch(UserDetailAction.ApiError(
                     error: error
@@ -39,5 +45,37 @@ final class UserDetailActionCreator: ActionCreator {
             .disposed(by: disposeBag)
     }
     
-    // TODO: Reposを取得するアクションを追加する
+    /// ユーザーに紐づくリポジトリ一覧を取得
+    func fetchUserRepositories(username: String, page: Int, perPage: Int) {
+        // 読み込み開始
+        dispatch(UserDetailAction.ReposListFetchStart())
+        
+        reposRepository.fetchList(username: username, page: page, perPage: perPage)
+            .subscribe(with: self, onSuccess: { owner, reposList in
+                // 読み込み終了
+                owner.dispatch(UserDetailAction.ReposListFetchEnd())
+                
+                if page <= 1 {
+                    owner.dispatch(UserDetailAction.ReposListFirstFetched(
+                        page: page,
+                        reposList: reposList,
+                        isDataEnded: reposList.count < perPage
+                    ))
+                } else {
+                    owner.dispatch(UserDetailAction.ReposListMoreFetched(
+                        page: page,
+                        reposList: reposList,
+                        isDataEnded: reposList.count < perPage
+                    ))
+                }
+            }, onFailure: { owner, error in
+                // 読み込み終了
+                owner.dispatch(UserDetailAction.ReposListFetchEnd())
+                
+                owner.dispatch(UserDetailAction.ApiError(
+                    error: error
+                ))
+            })
+            .disposed(by: disposeBag)
+    }
 }

--- a/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailState.swift
+++ b/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailState.swift
@@ -1,0 +1,12 @@
+//
+//  UserDetailState.swift
+//  FluxGithubApp
+//
+//  Created by Takahashi Shiko on 2022/04/24.
+//
+
+struct UserDetailState: ViewState {
+    let user: UserDetail?
+    let isLoading: Bool
+    let apiError: Error?
+}

--- a/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailState.swift
+++ b/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailState.swift
@@ -7,6 +7,12 @@
 
 struct UserDetailState: ViewState {
     let user: UserDetail?
+    let reposList: [Repos]
+    let reposPage: Int
     let isLoading: Bool
+    let isReposListFirstFetched: Bool
+    let isReposListLoading: Bool
+    let isReposListDataEnded: Bool
+    let canReposListFetchMore: Bool
     let apiError: Error?
 }

--- a/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailStore.swift
+++ b/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailStore.swift
@@ -13,7 +13,13 @@ final class UserDetailStore: Store {
     let state = BehaviorRelay<UserDetailState>(
         value: UserDetailState(
             user: nil,
+            reposList: [],
+            reposPage: 1,
             isLoading: false,
+            isReposListFirstFetched: false,
+            isReposListLoading: false,
+            isReposListDataEnded: false,
+            canReposListFetchMore: false,
             apiError: nil
         )
     )
@@ -25,33 +31,126 @@ final class UserDetailStore: Store {
         case let action as UserDetailAction.UserDetailFetched:
             state.accept(UserDetailState(
                 user: action.user,
+                reposList: current.reposList,
+                reposPage: current.reposPage,
                 isLoading: false,
+                isReposListFirstFetched: current.isReposListFirstFetched,
+                isReposListLoading: current.isReposListLoading,
+                isReposListDataEnded: current.isReposListDataEnded,
+                canReposListFetchMore: current.canReposListFetchMore,
+                apiError: nil
+            ))
+            
+        case let action as UserDetailAction.ReposListFirstFetched:
+            state.accept(UserDetailState(
+                user: current.user,
+                reposList: createViewableReposList(reposList: action.reposList),
+                reposPage: action.page,
+                isLoading: false,
+                isReposListFirstFetched: true,
+                isReposListLoading: current.isReposListLoading,
+                isReposListDataEnded: current.isReposListDataEnded,
+                canReposListFetchMore: canReposListFetchMore(
+                    isLoading: current.isReposListLoading,
+                    isDataEnded: action.isDataEnded,
+                    isFirstFetched: true
+                ),
+                apiError: nil
+            ))
+            
+        case let action as UserDetailAction.ReposListMoreFetched:
+            state.accept(UserDetailState(
+                user: current.user,
+                reposList: current.reposList + createViewableReposList(reposList: action.reposList),
+                reposPage: action.page,
+                isLoading: false,
+                isReposListFirstFetched: current.isReposListFirstFetched,
+                isReposListLoading: current.isReposListLoading,
+                isReposListDataEnded: current.isReposListDataEnded,
+                canReposListFetchMore: canReposListFetchMore(
+                    isLoading: current.isReposListLoading,
+                    isDataEnded: action.isDataEnded,
+                    isFirstFetched: current.isReposListFirstFetched
+                ),
                 apiError: nil
             ))
             
         case let action as UserDetailAction.ApiError:
             state.accept(UserDetailState(
                 user: current.user,
+                reposList: current.reposList,
+                reposPage: current.reposPage,
                 isLoading: false,
+                isReposListFirstFetched: current.isReposListFirstFetched,
+                isReposListLoading: current.isReposListLoading,
+                isReposListDataEnded: current.isReposListDataEnded,
+                canReposListFetchMore: current.canReposListFetchMore,
                 apiError: action.error
             ))
             
-        case _ as UserDetailAction.FirstFetchStart:
+        case _ as UserDetailAction.UserDetailFetchStart:
             state.accept(UserDetailState(
                 user: nil,
+                reposList: current.reposList,
+                reposPage: current.reposPage,
                 isLoading: true,
+                isReposListFirstFetched: current.isReposListFirstFetched,
+                isReposListLoading: current.isReposListLoading,
+                isReposListDataEnded: current.isReposListDataEnded,
+                canReposListFetchMore: current.canReposListFetchMore,
                 apiError: nil
             ))
             
-        case _ as UserDetailAction.FirstFetchEnd:
+        case _ as UserDetailAction.UserDetailFetchEnd:
             state.accept(UserDetailState(
                 user: current.user,
+                reposList: current.reposList,
+                reposPage: current.reposPage,
                 isLoading: false,
+                isReposListFirstFetched: current.isReposListFirstFetched,
+                isReposListLoading: current.isReposListLoading,
+                isReposListDataEnded: current.isReposListDataEnded,
+                canReposListFetchMore: current.canReposListFetchMore,
+                apiError: nil
+            ))
+            
+        case _ as UserDetailAction.ReposListFetchStart:
+            state.accept(UserDetailState(
+                user: current.user,
+                reposList: current.reposList,
+                reposPage: current.reposPage,
+                isLoading: current.isLoading,
+                isReposListFirstFetched: current.isReposListFirstFetched,
+                isReposListLoading: true,
+                isReposListDataEnded: current.isReposListDataEnded,
+                canReposListFetchMore: false,
+                apiError: nil
+            ))
+            
+        case _ as UserDetailAction.ReposListFetchEnd:
+            state.accept(UserDetailState(
+                user: current.user,
+                reposList: current.reposList,
+                reposPage: current.reposPage,
+                isLoading: current.isLoading,
+                isReposListFirstFetched: current.isReposListFirstFetched,
+                isReposListLoading: false,
+                isReposListDataEnded: current.isReposListDataEnded,
+                canReposListFetchMore: current.canReposListFetchMore,
                 apiError: nil
             ))
             
         default:
             break
         }
+    }
+    
+    /// 表示用のReposListを作成（Forkリポジトリを除く処理）
+    private func createViewableReposList(reposList: [Repos]) -> [Repos] {
+        return reposList.filter { !$0.isFork }
+    }
+    
+    private func canReposListFetchMore(isLoading: Bool, isDataEnded: Bool, isFirstFetched: Bool) -> Bool {
+        return !isLoading && !isDataEnded && isFirstFetched
     }
 }

--- a/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailStore.swift
+++ b/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailStore.swift
@@ -1,0 +1,57 @@
+//
+//  UserDetailStore.swift
+//  FluxGithubApp
+//
+//  Created by Takahashi Shiko on 2022/04/24.
+//
+
+import RxSwift
+import RxRelay
+
+final class UserDetailStore: Store {
+    
+    let state = BehaviorRelay<UserDetailState>(
+        value: UserDetailState(
+            user: nil,
+            isLoading: false,
+            apiError: nil
+        )
+    )
+    
+    override func onAction(action: Action) {
+        let current = state.value
+        
+        switch action {
+        case let action as UserDetailAction.UserDetailFetched:
+            state.accept(UserDetailState(
+                user: action.user,
+                isLoading: false,
+                apiError: nil
+            ))
+            
+        case let action as UserDetailAction.ApiError:
+            state.accept(UserDetailState(
+                user: current.user,
+                isLoading: false,
+                apiError: action.error
+            ))
+            
+        case _ as UserDetailAction.FirstFetchStart:
+            state.accept(UserDetailState(
+                user: nil,
+                isLoading: true,
+                apiError: nil
+            ))
+            
+        case _ as UserDetailAction.FirstFetchEnd:
+            state.accept(UserDetailState(
+                user: current.user,
+                isLoading: false,
+                apiError: nil
+            ))
+            
+        default:
+            break
+        }
+    }
+}

--- a/FluxGithubApp/FluxGithubApp/Flux/UserList/UserListStore.swift
+++ b/FluxGithubApp/FluxGithubApp/Flux/UserList/UserListStore.swift
@@ -111,7 +111,7 @@ final class UserListStore: Store {
                 apiError: nil
             ))
         default:
-            assertionFailure("意図しないアクションの通知を受け取りました。")
+            break
         }
     }
     

--- a/FluxGithubApp/FluxGithubApp/Models/Repos.swift
+++ b/FluxGithubApp/FluxGithubApp/Models/Repos.swift
@@ -1,0 +1,34 @@
+//
+//  Repos.swift
+//  FluxGithubApp
+//
+//  Created by Takahashi Shiko on 2022/04/24.
+//
+
+struct Repos: Decodable, Equatable, Hashable {
+    var id: Int
+    var name: String
+    var description: String?
+    var language: String?
+    var stargazersCount: Int
+    var isFork: Bool
+    var htmlUrl: String
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(self.id)
+    }
+
+    static func == (lhs: Repos, rhs: Repos) -> Bool {
+        return lhs.id == rhs.id
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case description
+        case language
+        case stargazersCount = "stargazers_count"
+        case isFork = "fork"
+        case htmlUrl = "html_url"
+    }
+}

--- a/FluxGithubApp/FluxGithubApp/Models/UserDetail.swift
+++ b/FluxGithubApp/FluxGithubApp/Models/UserDetail.swift
@@ -8,7 +8,7 @@
 struct UserDetail: Decodable, Equatable, Hashable {
     var id: Int
     var name: String
-    var fullName: String
+    var fullName: String?
     var avatarUrl: String
     var followerCount: Int
     var followingCount: Int

--- a/FluxGithubApp/FluxGithubApp/Models/UserDetail.swift
+++ b/FluxGithubApp/FluxGithubApp/Models/UserDetail.swift
@@ -1,0 +1,32 @@
+//
+//  UserDetail.swift
+//  FluxGithubApp
+//
+//  Created by Takahashi Shiko on 2022/04/24.
+//
+
+struct UserDetail: Decodable, Equatable, Hashable {
+    var id: Int
+    var name: String
+    var fullName: String
+    var avatarUrl: String
+    var followerCount: Int
+    var followingCount: Int
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(self.id)
+    }
+
+    static func == (lhs: UserDetail, rhs: UserDetail) -> Bool {
+        return lhs.id == rhs.id
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name = "login"
+        case fullName = "name"
+        case avatarUrl = "avatar_url"
+        case followerCount = "followers"
+        case followingCount = "following"
+    }
+}

--- a/FluxGithubApp/FluxGithubApp/Repositories/ReposRepository.swift
+++ b/FluxGithubApp/FluxGithubApp/Repositories/ReposRepository.swift
@@ -1,0 +1,29 @@
+//
+//  ReposRepository.swift
+//  FluxGithubApp
+//
+//  Created by Takahashi Shiko on 2022/04/24.
+//
+
+import RxSwift
+
+protocol ReposRepository {
+    func fetchList(username: String, page: Int, perPage: Int) -> Single<[Repos]>
+}
+
+final class ReposRepositoryImpl: ReposRepository {
+    private let client: ApiClient
+    
+    init(apiClient: ApiClient) {
+        self.client = apiClient
+    }
+    
+    /// ユーザーに紐づくリポジトリ一覧を取得
+    func fetchList(username: String, page: Int, perPage: Int) -> Single<[Repos]> {
+        return client.sendRequest(request: FetchReposListRequest(
+            username: username,
+            page: page,
+            perPage: perPage
+        ))
+    }
+}

--- a/FluxGithubApp/FluxGithubApp/Repositories/UserRepository.swift
+++ b/FluxGithubApp/FluxGithubApp/Repositories/UserRepository.swift
@@ -9,6 +9,7 @@ import RxSwift
 
 protocol UserRepository {
     func fetchList(since: Int, perPage: Int) -> Single<[User]>
+    func fetchDetail(username: String) -> Single<UserDetail>
 }
 
 final class UserRepositoryImpl: UserRepository {
@@ -20,6 +21,16 @@ final class UserRepositoryImpl: UserRepository {
     
     /// ユーザー一覧を取得
     func fetchList(since: Int, perPage: Int) -> Single<[User]> {
-        return client.fetchUserList(since: since, perPage: perPage)
+        return client.sendRequest(request: FetchUserListRequest(
+            since: since,
+            perPage: perPage
+        ))
+    }
+    
+    /// ユーザー詳細情報を取得
+    func fetchDetail(username: String) -> Single<UserDetail> {
+        return client.sendRequest(request: FetchUserDetailRequest(
+            username: username
+        ))
     }
 }

--- a/FluxGithubApp/FluxGithubApp/Request/Core/ApiClient.swift
+++ b/FluxGithubApp/FluxGithubApp/Request/Core/ApiClient.swift
@@ -17,12 +17,9 @@ class ApiClient {
         "Authorization": "Bearer \(Environments.GITHUB_PERSONAL_ACCESS_TOKEN)"
     ]
     
-    func fetchUserList(since: Int, perPage: Int) -> Single<([User])> {
-        var urlComponents = URLComponents(string: "https://api.github.com/users")
-        urlComponents?.queryItems = [
-            URLQueryItem(name: "since", value: "\(since)"),
-            URLQueryItem(name: "per_page", value: "\(perPage)")
-        ]
+    func sendRequest<Request: ApiRequestProtocol>(request: Request) -> Single<Request.Response> {
+        var urlComponents = URLComponents(string: request.requestUrl)
+        urlComponents?.queryItems = request.queryItems
         
         guard let requestUrl = urlComponents?.url else {
             return Single.create { event in
@@ -35,8 +32,8 @@ class ApiClient {
         request.allHTTPHeaderFields = self.header
         
         return URLSession.shared.rx.data(request: request)
-            .map { data -> [User] in
-                return try JSONDecoder().decode([User].self, from: data)
+            .map { data -> Request.Response in
+                return try JSONDecoder().decode(Request.Response.self, from: data)
             }
             .asSingle()
     }

--- a/FluxGithubApp/FluxGithubApp/Request/Core/ApiRequestProtocol.swift
+++ b/FluxGithubApp/FluxGithubApp/Request/Core/ApiRequestProtocol.swift
@@ -1,0 +1,21 @@
+//
+//  ApiRequestProtocol.swift
+//  FluxGithubApp
+//
+//  Created by Takahashi Shiko on 2022/04/24.
+//
+
+import Foundation
+
+protocol ApiRequestProtocol {
+    associatedtype Response: Decodable
+    
+    var path: String { get }
+    var queryItems: [URLQueryItem]? { get }
+}
+
+extension ApiRequestProtocol {
+    var requestUrl: String {
+        return "https://api.github.com/" + path
+    }
+}

--- a/FluxGithubApp/FluxGithubApp/Request/FetchReposListRequest.swift
+++ b/FluxGithubApp/FluxGithubApp/Request/FetchReposListRequest.swift
@@ -1,0 +1,23 @@
+//
+//  FetchReposListRequest.swift
+//  FluxGithubApp
+//
+//  Created by Takahashi Shiko on 2022/04/24.
+//
+
+import Foundation
+
+struct FetchReposListRequest: ApiRequestProtocol {
+    typealias Response = [Repos]
+    
+    init(username: String, page: Int, perPage: Int) {
+        path = "users/\(username)/repos"
+        queryItems = [
+            URLQueryItem(name: "page", value: "\(page)"),
+            URLQueryItem(name: "per_page", value: "\(perPage)")
+        ]
+    }
+    
+    var path: String
+    var queryItems: [URLQueryItem]?
+}

--- a/FluxGithubApp/FluxGithubApp/Request/FetchUserDetailRequest.swift
+++ b/FluxGithubApp/FluxGithubApp/Request/FetchUserDetailRequest.swift
@@ -1,0 +1,19 @@
+//
+//  FetchUserDetailRequest.swift
+//  FluxGithubApp
+//
+//  Created by Takahashi Shiko on 2022/04/24.
+//
+
+import Foundation
+
+struct FetchUserDetailRequest: ApiRequestProtocol {
+    typealias Response = UserDetail
+    
+    init(username: String) {
+        path = "users/\(username)"
+    }
+    
+    var path: String
+    var queryItems: [URLQueryItem]? = nil
+}

--- a/FluxGithubApp/FluxGithubApp/Request/FetchUserListRequest.swift
+++ b/FluxGithubApp/FluxGithubApp/Request/FetchUserListRequest.swift
@@ -1,0 +1,22 @@
+//
+//  FetchUserListRequest.swift
+//  FluxGithubApp
+//
+//  Created by Takahashi Shiko on 2022/04/24.
+//
+
+import Foundation
+
+struct FetchUserListRequest: ApiRequestProtocol {
+    typealias Response = [User]
+    
+    init(since: Int, perPage: Int) {
+        queryItems = [
+            URLQueryItem(name: "since", value: "\(since)"),
+            URLQueryItem(name: "per_page", value: "\(perPage)")
+        ]
+    }
+    
+    var path: String = "users"
+    var queryItems: [URLQueryItem]?
+}

--- a/FluxGithubApp/FluxGithubApp/ViewModels/UserDetailViewModel.swift
+++ b/FluxGithubApp/FluxGithubApp/ViewModels/UserDetailViewModel.swift
@@ -9,20 +9,32 @@ import RxSwift
 
 protocol UserDetailViewModelInput {
     func fetchUserDetail(username: String)
+    func fetchReposList(username: String)
+    func fetchMoreReposList(username: String)
 }
 
 protocol UserDetailViewModelOutput {
     var user: Observable<UserDetail?> { get }
+    var reposList: Observable<[Repos]> { get }
     var isLoading: Observable<Bool> { get }
+    var isReposListLoading: Observable<Bool> { get }
+    var isReposListDataEnded: Observable<Bool> { get }
+    var canReposListFetchMore: Observable<Bool> { get }
     var apiError: Observable<Error?> { get }
 }
 
 class UserDetailViewModel: UserDetailViewModelInput, UserDetailViewModelOutput {
+    private let PER_PAGE = 20
+    
     private let actionCreator: UserDetailActionCreator
     private let store: UserDetailStore
     
     var user: Observable<UserDetail?>
+    var reposList: Observable<[Repos]>
     var isLoading: Observable<Bool>
+    var isReposListLoading: Observable<Bool>
+    var isReposListDataEnded: Observable<Bool>
+    var canReposListFetchMore: Observable<Bool>
     var apiError: Observable<Error?>
     
     init(actionCreator: UserDetailActionCreator, store: UserDetailStore) {
@@ -34,8 +46,28 @@ class UserDetailViewModel: UserDetailViewModelInput, UserDetailViewModelOutput {
         }
         .share()
         
+        self.reposList = store.state.map { state in
+            state.reposList
+        }
+        .share()
+        
         self.isLoading = store.state.map { state in
             state.isLoading
+        }
+        .share()
+        
+        self.isReposListLoading = store.state.map { state in
+            state.isReposListLoading
+        }
+        .share()
+        
+        self.isReposListDataEnded = store.state.map { state in
+            state.isReposListDataEnded
+        }
+        .share()
+        
+        self.canReposListFetchMore = store.state.map { state in
+            state.canReposListFetchMore
         }
         .share()
         
@@ -47,5 +79,23 @@ class UserDetailViewModel: UserDetailViewModelInput, UserDetailViewModelOutput {
     
     func fetchUserDetail(username: String) {
         actionCreator.fetchUserDetail(username: username)
+    }
+    
+    func fetchReposList(username: String) {
+        actionCreator.fetchUserRepositories(
+            username: username,
+            page: 1,
+            perPage: PER_PAGE
+        )
+    }
+    
+    func fetchMoreReposList(username: String) {
+        let state = store.state.value
+        
+        actionCreator.fetchUserRepositories(
+            username: username,
+            page: state.reposPage + 1,
+            perPage: PER_PAGE
+        )
     }
 }

--- a/FluxGithubApp/FluxGithubApp/ViewModels/UserDetailViewModel.swift
+++ b/FluxGithubApp/FluxGithubApp/ViewModels/UserDetailViewModel.swift
@@ -1,0 +1,51 @@
+//
+//  UserDetailViewModel.swift
+//  FluxGithubApp
+//
+//  Created by Takahashi Shiko on 2022/04/24.
+//
+
+import RxSwift
+
+protocol UserDetailViewModelInput {
+    func fetchUserDetail(username: String)
+}
+
+protocol UserDetailViewModelOutput {
+    var user: Observable<UserDetail?> { get }
+    var isLoading: Observable<Bool> { get }
+    var apiError: Observable<Error?> { get }
+}
+
+class UserDetailViewModel: UserDetailViewModelInput, UserDetailViewModelOutput {
+    private let actionCreator: UserDetailActionCreator
+    private let store: UserDetailStore
+    
+    var user: Observable<UserDetail?>
+    var isLoading: Observable<Bool>
+    var apiError: Observable<Error?>
+    
+    init(actionCreator: UserDetailActionCreator, store: UserDetailStore) {
+        self.actionCreator = actionCreator
+        self.store = store
+        
+        self.user = store.state.map { state in
+            state.user
+        }
+        .share()
+        
+        self.isLoading = store.state.map { state in
+            state.isLoading
+        }
+        .share()
+        
+        self.apiError = store.state.map { state in
+            state.apiError
+        }
+        .share()
+    }
+    
+    func fetchUserDetail(username: String) {
+        actionCreator.fetchUserDetail(username: username)
+    }
+}

--- a/FluxGithubApp/FluxGithubApp/ViewModels/UserListViewModel.swift
+++ b/FluxGithubApp/FluxGithubApp/ViewModels/UserListViewModel.swift
@@ -75,12 +75,7 @@ class UserListViewModel: UserListViewModelInput, UserListViewModelOutput {
     
     func fetchMore() {
         let state = store.state.value
-        
         guard let since = state.users.last?.id else { return }
-        // 読み込み中 or すべてのデータ読み込み済み or 初回データ取得未取得
-        if state.isLoading || state.isDataEnded || !state.isFirstFetched {
-            return
-        }
         
         actionCreator.moreFetchUserList(since: since, perPage: PER_PAGE)
     }

--- a/FluxGithubApp/FluxGithubApp/ViewModels/UserListViewModel.swift
+++ b/FluxGithubApp/FluxGithubApp/ViewModels/UserListViewModel.swift
@@ -6,7 +6,6 @@
 //
 
 import RxSwift
-import SwiftUI
 
 protocol UserListViewModelInput {
     func fetchUserList()

--- a/FluxGithubApp/FluxGithubApp/Views/RepositoryDetail/RepositoryDetailViewController.swift
+++ b/FluxGithubApp/FluxGithubApp/Views/RepositoryDetail/RepositoryDetailViewController.swift
@@ -1,0 +1,30 @@
+//
+//  RepositoryDetailViewController.swift
+//  FluxGithubApp
+//
+//  Created by Takahashi Shiko on 2022/04/25.
+//
+
+import UIKit
+import WebKit
+
+class RepositoryDetailViewController: UIViewController, WKUIDelegate, WKNavigationDelegate {
+
+    var url: URL!
+    
+    private var webView: WKWebView!
+    
+    override func loadView() {
+        let webConfiguration = WKWebViewConfiguration()
+        webView = WKWebView(frame: .zero, configuration: webConfiguration)
+        webView.uiDelegate = self
+        webView.navigationDelegate = self
+        view = webView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        webView.load(URLRequest(url: url))
+    }
+}

--- a/FluxGithubApp/FluxGithubApp/Views/RepositoryDetail/RepositoryDetailViewController.swift
+++ b/FluxGithubApp/FluxGithubApp/Views/RepositoryDetail/RepositoryDetailViewController.swift
@@ -10,6 +10,7 @@ import WebKit
 
 class RepositoryDetailViewController: UIViewController, WKUIDelegate, WKNavigationDelegate {
 
+    // urlは必須
     var url: URL!
     
     private var webView: WKWebView!

--- a/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetail.storyboard
+++ b/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetail.storyboard
@@ -16,11 +16,13 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="aNM-7e-BTo">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="insetGrouped" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="aNM-7e-BTo">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
+                                <color key="separatorColor" systemColor="systemGrayColor"/>
                                 <connections>
-                                    <outlet property="delegate" destination="Y6W-OH-hqX" id="euQ-jE-kNf"/>
+                                    <outlet property="dataSource" destination="Y6W-OH-hqX" id="fdy-TB-Xmk"/>
+                                    <outlet property="delegate" destination="Y6W-OH-hqX" id="oH8-dN-yMl"/>
                                 </connections>
                             </tableView>
                         </subviews>
@@ -45,6 +47,12 @@
     <resources>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGrayColor">
+            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemGroupedBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetail.storyboard
+++ b/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetail.storyboard
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--User Detail View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController id="Y6W-OH-hqX" customClass="UserDetailViewController" customModule="FluxGithubApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="aNM-7e-BTo">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <connections>
+                                    <outlet property="delegate" destination="Y6W-OH-hqX" id="euQ-jE-kNf"/>
+                                </connections>
+                            </tableView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="yrM-gs-5UB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="aNM-7e-BTo" secondAttribute="trailing" id="adm-Ae-nrB"/>
+                            <constraint firstItem="aNM-7e-BTo" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="cJs-Eb-Km8"/>
+                            <constraint firstAttribute="bottom" secondItem="aNM-7e-BTo" secondAttribute="bottom" id="nzz-k6-NCj"/>
+                            <constraint firstItem="aNM-7e-BTo" firstAttribute="leading" secondItem="5EZ-qb-Rvc" secondAttribute="leading" id="uD9-pG-4Tm"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="tableView" destination="aNM-7e-BTo" id="Quv-d0-IjN"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="131.8840579710145" y="95.758928571428569"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetailTableViewCell.swift
+++ b/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetailTableViewCell.swift
@@ -22,14 +22,20 @@ class UserDetailTableViewCell: UITableViewCell {
         avatarImageView.layer.cornerRadius = avatarImageView.frame.height / 2
     }
     
-    func configure(user: UserDetail) {
-        avatarImageView.kf.setImage(
-            with: URL(string: user.avatarUrl),
-            placeholder: UIImage(systemName: "person.circle.fill")
-        )
-        
-        userNameLabel.text = user.name
-        fullNameLabel.text = user.fullName
-        followerAndFollowingLabel.text = String.init(format: "%dフォロワー・%dフォロー中", user.followerCount, user.followingCount)
+    func configure(user: UserDetail?) {
+        if let user = user {
+            avatarImageView.kf.setImage(
+                with: URL(string: user.avatarUrl),
+                placeholder: UIImage(systemName: "person.circle.fill")
+            )
+            userNameLabel.text = user.name
+            fullNameLabel.text = user.fullName
+            followerAndFollowingLabel.text = String.init(format: "%dフォロワー・%dフォロー中", user.followerCount, user.followingCount)
+        } else {
+            avatarImageView.image = UIImage(systemName: "person.circle.fill")
+            userNameLabel.text = nil
+            fullNameLabel.text = nil
+            followerAndFollowingLabel.text = nil
+        }
     }
 }

--- a/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetailTableViewCell.swift
+++ b/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetailTableViewCell.swift
@@ -1,0 +1,35 @@
+//
+//  UserDetailTableViewCell.swift
+//  FluxGithubApp
+//
+//  Created by Takahashi Shiko on 2022/04/24.
+//
+
+import UIKit
+import Kingfisher
+
+class UserDetailTableViewCell: UITableViewCell {
+    
+    @IBOutlet weak var avatarImageView: UIImageView!
+    @IBOutlet weak var userNameLabel: UILabel!
+    @IBOutlet weak var fullNameLabel: UILabel!
+    @IBOutlet weak var followerAndFollowingLabel: UILabel!
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        
+        avatarImageView.layer.masksToBounds = true
+        avatarImageView.layer.cornerRadius = avatarImageView.frame.height / 2
+    }
+    
+    func configure(user: UserDetail) {
+        avatarImageView.kf.setImage(
+            with: URL(string: user.avatarUrl),
+            placeholder: UIImage(systemName: "person.circle.fill")
+        )
+        
+        userNameLabel.text = user.name
+        fullNameLabel.text = user.fullName
+        followerAndFollowingLabel.text = String.init(format: "%dフォロワー・%dフォロー中", user.followerCount, user.followingCount)
+    }
+}

--- a/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetailTableViewCell.xib
+++ b/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetailTableViewCell.xib
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="113" id="KGk-i7-Jjw" customClass="UserDetailTableViewCell" customModule="FluxGithubApp" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="589" height="113"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="589" height="113"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="vX6-yt-QgV">
+                        <rect key="frame" x="0.0" y="0.0" width="589" height="110"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lyM-Pm-hDL">
+                                <rect key="frame" x="0.0" y="0.0" width="589" height="80"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="person.circle.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Ofw-Vx-xcS">
+                                        <rect key="frame" x="16" y="10.5" width="60" height="59"/>
+                                        <color key="tintColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="60" id="6QQ-80-5OG"/>
+                                            <constraint firstAttribute="height" constant="60" id="Mgr-JZ-UJF"/>
+                                        </constraints>
+                                    </imageView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="Oyz-2c-vDP">
+                                        <rect key="frame" x="86" y="16" width="493" height="48"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ユーザー名" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JRv-GU-GWu">
+                                                <rect key="frame" x="0.0" y="0.0" width="92" height="21.5"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                                                <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="フルネーム" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O0p-Dp-EDQ">
+                                                <rect key="frame" x="0.0" y="31" width="71.5" height="17"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstItem="Ofw-Vx-xcS" firstAttribute="leading" secondItem="lyM-Pm-hDL" secondAttribute="leading" constant="16" id="9CE-D6-RgU"/>
+                                    <constraint firstItem="Oyz-2c-vDP" firstAttribute="top" secondItem="lyM-Pm-hDL" secondAttribute="top" constant="16" id="NgC-eh-Pj0"/>
+                                    <constraint firstAttribute="bottom" secondItem="Ofw-Vx-xcS" secondAttribute="bottom" constant="10" id="Uku-Bf-3xy"/>
+                                    <constraint firstAttribute="trailing" secondItem="Oyz-2c-vDP" secondAttribute="trailing" constant="10" id="XdG-IQ-qvE"/>
+                                    <constraint firstItem="Oyz-2c-vDP" firstAttribute="leading" secondItem="Ofw-Vx-xcS" secondAttribute="trailing" constant="10" id="abR-ey-paM"/>
+                                    <constraint firstItem="Ofw-Vx-xcS" firstAttribute="top" secondItem="lyM-Pm-hDL" secondAttribute="top" constant="10" id="hWP-EC-hFZ"/>
+                                    <constraint firstAttribute="bottom" secondItem="Oyz-2c-vDP" secondAttribute="bottom" constant="16" id="pbT-eV-cux"/>
+                                    <constraint firstItem="Oyz-2c-vDP" firstAttribute="centerY" secondItem="Ofw-Vx-xcS" secondAttribute="centerY" id="zh5-qR-yYA"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ggd-Xb-PpC">
+                                <rect key="frame" x="0.0" y="80" width="589" height="30"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4f0-6Z-ejb">
+                                        <rect key="frame" x="16" y="6.5" width="557" height="17"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstItem="4f0-6Z-ejb" firstAttribute="top" secondItem="Ggd-Xb-PpC" secondAttribute="top" constant="6.5" id="LXG-Ze-zzO"/>
+                                    <constraint firstAttribute="height" constant="30" id="Vth-Ud-hEm"/>
+                                    <constraint firstAttribute="trailing" secondItem="4f0-6Z-ejb" secondAttribute="trailing" constant="16" id="Z2O-p6-gq7"/>
+                                    <constraint firstAttribute="bottom" secondItem="4f0-6Z-ejb" secondAttribute="bottom" constant="6.5" id="ZWZ-rf-qjl"/>
+                                    <constraint firstItem="4f0-6Z-ejb" firstAttribute="leading" secondItem="Ggd-Xb-PpC" secondAttribute="leading" constant="16" id="sag-8c-5Xj"/>
+                                    <constraint firstItem="4f0-6Z-ejb" firstAttribute="centerY" secondItem="Ggd-Xb-PpC" secondAttribute="centerY" id="tAe-V9-2yg"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="bottom" secondItem="vX6-yt-QgV" secondAttribute="bottom" id="4BJ-0d-3M5"/>
+                    <constraint firstItem="vX6-yt-QgV" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="75v-zK-IYq"/>
+                    <constraint firstItem="vX6-yt-QgV" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="CY5-Np-TFt"/>
+                    <constraint firstAttribute="trailing" secondItem="vX6-yt-QgV" secondAttribute="trailing" id="Peg-0x-4dz"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="avatarImageView" destination="Ofw-Vx-xcS" id="2Vo-g8-POy"/>
+                <outlet property="followerAndFollowingLabel" destination="4f0-6Z-ejb" id="bnY-5I-ktb"/>
+                <outlet property="fullNameLabel" destination="O0p-Dp-EDQ" id="7Em-Wi-I33"/>
+                <outlet property="userNameLabel" destination="JRv-GU-GWu" id="obK-vJ-zZl"/>
+            </connections>
+            <point key="canvasLocation" x="434.05797101449281" y="153.68303571428569"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <image name="person.circle.fill" catalog="system" width="128" height="121"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetailTableViewCell.xib
+++ b/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetailTableViewCell.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="113" id="KGk-i7-Jjw" customClass="UserDetailTableViewCell" customModule="FluxGithubApp" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="113" id="KGk-i7-Jjw" customClass="UserDetailTableViewCell" customModule="FluxGithubApp" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="589" height="113"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">

--- a/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetailViewController.swift
+++ b/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetailViewController.swift
@@ -1,0 +1,117 @@
+//
+//  UserDetailViewController.swift
+//  FluxGithubApp
+//
+//  Created by Takahashi Shiko on 2022/04/24.
+//
+
+import UIKit
+import RxSwift
+import PKHUD
+
+class UserDetailViewController: UIViewController {
+    
+    private enum SectionType: CaseIterable {
+        case userDetail
+        case repositories
+    }
+    
+    @IBOutlet weak var tableView: UITableView!
+    
+    private let disposeBag = DisposeBag()
+    
+    private lazy var dataSource: UITableViewDiffableDataSource<SectionType, UserDetail> = {
+        let dataSource = UITableViewDiffableDataSource<SectionType, UserDetail>(tableView: tableView) { tableView, indexPath, user in
+            let cell = tableView.dequeueReusableCell(withIdentifier: UserDetailTableViewCell.className, for: indexPath) as! UserDetailTableViewCell
+            cell.configure(user: user)
+            return cell
+        }
+        
+        return dataSource
+    }()
+    
+    private var user: UserDetail? {
+        didSet {
+            var snapshot = NSDiffableDataSourceSnapshot<SectionType, UserDetail>()
+            snapshot.appendSections(SectionType.allCases)
+            if let user = user {
+                snapshot.appendItems([user], toSection: .userDetail)
+            } else {
+                snapshot.appendItems([], toSection: .userDetail)
+            }
+            dataSource.apply(snapshot, animatingDifferences: true)
+        }
+    }
+    
+    var viewModelInput: UserDetailViewModelInput?
+    var viewModelOutput: UserDetailViewModelOutput?
+    // usernameは必須
+    var username: String!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // セル登録
+        tableView.register(UINib.init(nibName: UserDetailTableViewCell.className, bundle: nil), forCellReuseIdentifier: UserDetailTableViewCell.className)
+        
+        viewModelInput?.fetchUserDetail(username: username)
+        
+        setTableViewSubscribes()
+        setViewModelSubscribes()
+    }
+    
+    private func setTableViewSubscribes() {
+        // タップアクション
+//        tableView.rx.itemSelected
+//            .asSignal()
+//            .emit(with: self, onNext: { owner, indexPath in
+//                // TODO: リポジトリセクションのみWebViewに遷移する
+//                owner.tableView.deselectRow(at: indexPath, animated: true)
+//                print(indexPath)
+//            })
+//            .disposed(by: disposeBag)
+//
+//        // 最下部の読み込み処理
+//        tableView.rx.willDisplayCell
+//            .asDriver()
+//            .drive(onNext: { [weak self] cell, indexPath in
+//                guard let strongSelf = self else { return }
+//
+//                // TODO: リポジトリセクションのみ対応する
+//            })
+//            .disposed(by: disposeBag)
+    }
+    
+    private func setViewModelSubscribes() {
+        // ユーザー一覧
+        viewModelOutput?.user
+            .distinctUntilChanged()
+            .asDriver(onErrorJustReturn: nil)
+            .drive(with: self, onNext: { owner, user in
+                owner.user = user
+            })
+            .disposed(by: disposeBag)
+        
+        // ローディング
+        viewModelOutput?.isLoading
+            .distinctUntilChanged()
+            .asDriver(onErrorJustReturn: false)
+            .drive(onNext: { isLoading in
+                if isLoading {
+                    HUD.show(.progress)
+                } else {
+                    HUD.hide()
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        // APIエラー
+        viewModelOutput?.apiError
+            .asDriver(onErrorJustReturn: nil)
+            .drive(onNext: { error in
+                guard let error = error else { return }
+                HUD.show(.labeledError(title: "Network Error", subtitle: error.localizedDescription))
+            })
+            .disposed(by: disposeBag)
+    }
+}

--- a/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetailViewController.swift
+++ b/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetailViewController.swift
@@ -11,50 +11,49 @@ import PKHUD
 
 class UserDetailViewController: UIViewController {
     
-    private enum SectionType: CaseIterable {
-        case userDetail
-        case repositories
+    private enum SectionType: Int, CaseIterable {
+        case userDetail = 0
+        case reposList = 1
     }
     
     @IBOutlet weak var tableView: UITableView!
     
+    // usernameは必須
+    var username: String!
+    var viewModelInput: UserDetailViewModelInput?
+    var viewModelOutput: UserDetailViewModelOutput?
+    
     private let disposeBag = DisposeBag()
-    
-    private lazy var dataSource: UITableViewDiffableDataSource<SectionType, UserDetail> = {
-        let dataSource = UITableViewDiffableDataSource<SectionType, UserDetail>(tableView: tableView) { tableView, indexPath, user in
-            let cell = tableView.dequeueReusableCell(withIdentifier: UserDetailTableViewCell.className, for: indexPath) as! UserDetailTableViewCell
-            cell.configure(user: user)
-            return cell
-        }
-        
-        return dataSource
-    }()
-    
+    private let indicatorView = UIActivityIndicatorView(style: .medium)
+    // ユーザー詳細
     private var user: UserDetail? {
         didSet {
-            var snapshot = NSDiffableDataSourceSnapshot<SectionType, UserDetail>()
-            snapshot.appendSections(SectionType.allCases)
-            if let user = user {
-                snapshot.appendItems([user], toSection: .userDetail)
-            } else {
-                snapshot.appendItems([], toSection: .userDetail)
-            }
-            dataSource.apply(snapshot, animatingDifferences: true)
+            tableView.reloadData()
+        }
+    }
+    // リポジトリリスト
+    private var reposList = [Repos]() {
+        didSet {
+            print(reposList.count)
+            tableView.reloadData()
         }
     }
     
-    var viewModelInput: UserDetailViewModelInput?
-    var viewModelOutput: UserDetailViewModelOutput?
-    // usernameは必須
-    var username: String!
+    private var canReposListFetchMore = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
         
         // セル登録
         tableView.register(UINib.init(nibName: UserDetailTableViewCell.className, bundle: nil), forCellReuseIdentifier: UserDetailTableViewCell.className)
+        tableView.register(UINib.init(nibName: UserReposTableViewCell.className, bundle: nil), forCellReuseIdentifier: UserReposTableViewCell.className)
+        
+        // tableViewの設定
+        tableView.estimatedRowHeight = 80
+        tableView.rowHeight = UITableView.automaticDimension
         
         viewModelInput?.fetchUserDetail(username: username)
+        viewModelInput?.fetchReposList(username: username)
         
         setTableViewSubscribes()
         setViewModelSubscribes()
@@ -62,24 +61,34 @@ class UserDetailViewController: UIViewController {
     
     private func setTableViewSubscribes() {
         // タップアクション
-//        tableView.rx.itemSelected
-//            .asSignal()
-//            .emit(with: self, onNext: { owner, indexPath in
-//                // TODO: リポジトリセクションのみWebViewに遷移する
-//                owner.tableView.deselectRow(at: indexPath, animated: true)
-//                print(indexPath)
-//            })
-//            .disposed(by: disposeBag)
-//
-//        // 最下部の読み込み処理
-//        tableView.rx.willDisplayCell
-//            .asDriver()
-//            .drive(onNext: { [weak self] cell, indexPath in
-//                guard let strongSelf = self else { return }
-//
-//                // TODO: リポジトリセクションのみ対応する
-//            })
-//            .disposed(by: disposeBag)
+        tableView.rx.itemSelected
+            .asSignal()
+            .emit(with: self, onNext: { owner, indexPath in
+                if SectionType(rawValue: indexPath.section) != .reposList {
+                    return
+                }
+                // TODO: リポジトリセクションのみWebViewに遷移する
+                owner.tableView.deselectRow(at: indexPath, animated: true)
+                
+                print(indexPath)
+            })
+            .disposed(by: disposeBag)
+
+        // 最下部の読み込み処理
+        tableView.rx.willDisplayCell
+            .asDriver()
+            .drive(onNext: { [weak self] cell, indexPath in
+                if SectionType(rawValue: indexPath.section) != .reposList {
+                    return
+                }
+                
+                guard let strongSelf = self else { return }
+
+                if strongSelf.canReposListFetchMore, indexPath.row >= (strongSelf.reposList.count - 2) {
+                    strongSelf.viewModelInput?.fetchMoreReposList(username: strongSelf.username)
+                }
+            })
+            .disposed(by: disposeBag)
     }
     
     private func setViewModelSubscribes() {
@@ -89,6 +98,36 @@ class UserDetailViewController: UIViewController {
             .asDriver(onErrorJustReturn: nil)
             .drive(with: self, onNext: { owner, user in
                 owner.user = user
+            })
+            .disposed(by: disposeBag)
+        
+        // リポジトリ一覧
+        viewModelOutput?.reposList
+            .distinctUntilChanged()
+            .asDriver(onErrorJustReturn: [])
+            .drive(with: self, onNext: { owner, reposList in
+                owner.reposList = reposList
+            })
+            .disposed(by: disposeBag)
+        
+        // 追加取得可能フラグ
+        viewModelOutput?.canReposListFetchMore
+            .distinctUntilChanged()
+            .subscribe(with: self, onNext: { owner, canReposListFetchMore in
+                owner.canReposListFetchMore = canReposListFetchMore
+            })
+            .disposed(by: disposeBag)
+        
+        // 全てのデータ取得完了フラグ
+        viewModelOutput?.isReposListDataEnded
+            .distinctUntilChanged()
+            .asDriver(onErrorJustReturn: false)
+            .drive(with: self, onNext: { owner, isReposListDataEnded in
+                if isReposListDataEnded {
+                    owner.tableView.tableFooterView = UIView()
+                } else {
+                    owner.tableView.tableFooterView = owner.indicatorView
+                }
             })
             .disposed(by: disposeBag)
         
@@ -105,6 +144,19 @@ class UserDetailViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
+        // リポジトリリストのローディング
+        viewModelOutput?.isReposListLoading
+            .distinctUntilChanged()
+            .asDriver(onErrorJustReturn: false)
+            .drive(with: self, onNext: { owner, isReposListLoading in
+                if isReposListLoading {
+                    owner.indicatorView.startAnimating()
+                } else {
+                    owner.indicatorView.stopAnimating()
+                }
+            })
+            .disposed(by: disposeBag)
+        
         // APIエラー
         viewModelOutput?.apiError
             .asDriver(onErrorJustReturn: nil)
@@ -113,5 +165,44 @@ class UserDetailViewController: UIViewController {
                 HUD.show(.labeledError(title: "Network Error", subtitle: error.localizedDescription))
             })
             .disposed(by: disposeBag)
+    }
+}
+
+extension UserDetailViewController: UITableViewDataSource, UITableViewDelegate {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return SectionType.allCases.count
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        switch SectionType(rawValue: section) {
+        case .userDetail:
+            return 1
+        case .reposList:
+            return reposList.count
+        default:
+            return 0
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let sectionType = SectionType(rawValue: indexPath.section) else {
+            return UITableViewCell()
+        }
+
+        switch sectionType {
+        case .userDetail:
+            let cell = tableView.dequeueReusableCell(withIdentifier: UserDetailTableViewCell.className, for: indexPath) as! UserDetailTableViewCell
+            cell.configure(user: user)
+            return cell
+
+        case .reposList:
+            let cell = tableView.dequeueReusableCell(withIdentifier: UserReposTableViewCell.className, for: indexPath) as! UserReposTableViewCell
+            cell.configure(repos: reposList[indexPath.row])
+            return cell
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableView.automaticDimension
     }
 }

--- a/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetailViewController.swift
+++ b/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetailViewController.swift
@@ -34,7 +34,6 @@ class UserDetailViewController: UIViewController {
     // リポジトリリスト
     private var reposList = [Repos]() {
         didSet {
-            print(reposList.count)
             tableView.reloadData()
         }
     }

--- a/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetailViewController.swift
+++ b/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetailViewController.swift
@@ -67,10 +67,16 @@ class UserDetailViewController: UIViewController {
                 if SectionType(rawValue: indexPath.section) != .reposList {
                     return
                 }
-                // TODO: リポジトリセクションのみWebViewに遷移する
+                
                 owner.tableView.deselectRow(at: indexPath, animated: true)
                 
-                print(indexPath)
+                guard let url = URL(string: owner.reposList[indexPath.row].htmlUrl) else {
+                    return
+                }
+                
+                let viewController = RepositoryDetailViewController()
+                viewController.url = url
+                owner.navigationController?.pushViewController(viewController, animated: true)
             })
             .disposed(by: disposeBag)
 

--- a/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserReposTableViewCell.swift
+++ b/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserReposTableViewCell.swift
@@ -1,0 +1,28 @@
+//
+//  UserReposTableViewCell.swift
+//  FluxGithubApp
+//
+//  Created by Takahashi Shiko on 2022/04/25.
+//
+
+import UIKit
+
+class UserReposTableViewCell: UITableViewCell {
+    
+    @IBOutlet weak var languageTextView: UIView!
+    @IBOutlet weak var languageLabel: UILabel!
+    @IBOutlet weak var starCountLabel: UILabel!
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var descriptionLabel: UILabel!
+    
+    func configure(repos: Repos) {
+        languageTextView.isHidden = repos.language == nil
+        languageLabel.text = repos.language
+        starCountLabel.text = "\(repos.stargazersCount)"
+        
+        titleLabel.text = repos.name
+        
+        descriptionLabel.isHidden = repos.description == nil
+        descriptionLabel.text = repos.description
+    }
+}

--- a/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserReposTableViewCell.xib
+++ b/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserReposTableViewCell.xib
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="191" id="KGk-i7-Jjw" customClass="UserReposTableViewCell" customModule="FluxGithubApp" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="472" height="191"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="472" height="191"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6yD-eI-7w3">
+                        <rect key="frame" x="8" y="16" width="456" height="159"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="xZf-IB-B9R">
+                                <rect key="frame" x="0.0" y="0.0" width="456" height="35"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X3o-wg-z8Q">
+                                        <rect key="frame" x="0.0" y="0.0" width="118" height="35"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Language" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r5i-vM-lVv">
+                                                <rect key="frame" x="26" y="8" width="84" height="19"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="tag.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="uDN-UF-I09">
+                                                <rect key="frame" x="0.0" y="7.5" width="20" height="21"/>
+                                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="20" id="3pq-V2-cZV"/>
+                                                    <constraint firstAttribute="width" constant="20" id="EBh-Ro-3FV"/>
+                                                </constraints>
+                                            </imageView>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="trailing" secondItem="r5i-vM-lVv" secondAttribute="trailing" constant="8" id="4I8-L1-eVC"/>
+                                            <constraint firstItem="r5i-vM-lVv" firstAttribute="top" secondItem="X3o-wg-z8Q" secondAttribute="top" constant="8" id="H9Q-nD-ChL"/>
+                                            <constraint firstItem="r5i-vM-lVv" firstAttribute="centerY" secondItem="X3o-wg-z8Q" secondAttribute="centerY" id="QhI-QD-Nu8"/>
+                                            <constraint firstItem="uDN-UF-I09" firstAttribute="centerY" secondItem="X3o-wg-z8Q" secondAttribute="centerY" id="a70-qC-dST"/>
+                                            <constraint firstAttribute="bottom" secondItem="r5i-vM-lVv" secondAttribute="bottom" constant="8" id="dJW-Yb-JJs"/>
+                                            <constraint firstItem="uDN-UF-I09" firstAttribute="leading" secondItem="X3o-wg-z8Q" secondAttribute="leading" id="dy0-am-2jM"/>
+                                            <constraint firstItem="r5i-vM-lVv" firstAttribute="leading" secondItem="uDN-UF-I09" secondAttribute="trailing" constant="6" id="i4e-IX-Zgg"/>
+                                            <constraint firstItem="r5i-vM-lVv" firstAttribute="centerY" secondItem="uDN-UF-I09" secondAttribute="centerY" id="o26-Cz-9br"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YYV-Cy-uR7">
+                                        <rect key="frame" x="122" y="0.0" width="90" height="35"/>
+                                        <subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="star.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="uzd-gV-Qmb">
+                                                <rect key="frame" x="0.0" y="7" width="20" height="20"/>
+                                                <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="20" id="bc7-Mj-V7x"/>
+                                                    <constraint firstAttribute="height" constant="20" id="dGc-hC-rIr"/>
+                                                </constraints>
+                                            </imageView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lrE-db-cgd">
+                                                <rect key="frame" x="26" y="8" width="64" height="19.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="uzd-gV-Qmb" firstAttribute="centerY" secondItem="YYV-Cy-uR7" secondAttribute="centerY" id="CnZ-ho-Hb5"/>
+                                            <constraint firstItem="uzd-gV-Qmb" firstAttribute="leading" secondItem="YYV-Cy-uR7" secondAttribute="leading" id="Epp-dQ-YAr"/>
+                                            <constraint firstItem="lrE-db-cgd" firstAttribute="leading" secondItem="uzd-gV-Qmb" secondAttribute="trailing" constant="6" id="Mpj-nD-fEA"/>
+                                            <constraint firstItem="lrE-db-cgd" firstAttribute="centerY" secondItem="uzd-gV-Qmb" secondAttribute="centerY" id="OUy-tj-lX4"/>
+                                            <constraint firstAttribute="trailing" secondItem="lrE-db-cgd" secondAttribute="trailing" id="uDG-VG-ksE"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lKo-bX-qol">
+                                        <rect key="frame" x="216" y="0.0" width="240" height="35"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                    </view>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="35" id="ZSv-5i-Zj3"/>
+                                </constraints>
+                            </stackView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c2W-Ih-64H">
+                                <rect key="frame" x="0.0" y="43" width="456" height="39.5"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                                <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Description" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hJi-PH-VxH">
+                                <rect key="frame" x="0.0" y="90.5" width="456" height="68.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="6yD-eI-7w3" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="AAT-lh-hUc"/>
+                    <constraint firstAttribute="trailing" secondItem="6yD-eI-7w3" secondAttribute="trailing" constant="8" id="Efy-d5-BtD"/>
+                    <constraint firstAttribute="bottom" secondItem="6yD-eI-7w3" secondAttribute="bottom" constant="16" id="XMO-oe-HPP"/>
+                    <constraint firstItem="6yD-eI-7w3" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="8" id="yjs-BP-LjG"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <connections>
+                <outlet property="descriptionLabel" destination="hJi-PH-VxH" id="GRB-77-ujM"/>
+                <outlet property="languageLabel" destination="r5i-vM-lVv" id="eiB-hK-jjd"/>
+                <outlet property="languageTextView" destination="X3o-wg-z8Q" id="ioW-xH-IyT"/>
+                <outlet property="starCountLabel" destination="lrE-db-cgd" id="Wl4-CZ-LMx"/>
+                <outlet property="titleLabel" destination="c2W-Ih-64H" id="fIg-Vh-I4C"/>
+            </connections>
+            <point key="canvasLocation" x="242.0289855072464" y="160.37946428571428"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <image name="star.fill" catalog="system" width="128" height="116"/>
+        <image name="tag.fill" catalog="system" width="128" height="119"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/FluxGithubApp/FluxGithubApp/Views/UserList/UserListTableViewCell.swift
+++ b/FluxGithubApp/FluxGithubApp/Views/UserList/UserListTableViewCell.swift
@@ -22,6 +22,9 @@ class UserListTableViewCell: UITableViewCell {
     
     func configure(user: User) {
         nameLabel.text = user.name
-        avatarImageView.kf.setImage(with: URL(string: user.avatarUrl))
+        avatarImageView.kf.setImage(
+            with: URL(string: user.avatarUrl),
+            placeholder: UIImage(systemName: "person.circle.fill")
+        )
     }
 }

--- a/FluxGithubApp/FluxGithubApp/Views/UserList/UserListViewController.swift
+++ b/FluxGithubApp/FluxGithubApp/Views/UserList/UserListViewController.swift
@@ -75,9 +75,7 @@ class UserListViewController: UIViewController {
         tableView.rx.itemSelected
             .asSignal()
             .emit(with: self, onNext: { owner, indexPath in
-                // TODO: ユーザー詳細ページへ遷移する処理を実装
                 owner.tableView.deselectRow(at: indexPath, animated: true)
-                print(indexPath)
                 
                 let user = owner.userList[indexPath.row]
                 let viewController = UserDetailViewController.instantiate()

--- a/FluxGithubApp/FluxGithubApp/Views/UserList/UserListViewController.swift
+++ b/FluxGithubApp/FluxGithubApp/Views/UserList/UserListViewController.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import SwiftUI
 import RxSwift
 import PKHUD
 
@@ -32,6 +31,7 @@ class UserListViewController: UIViewController {
         
         return dataSource
     }()
+    // ユーザーリスト
     private var userList = [User]() {
         didSet {
             var snapshot = NSDiffableDataSourceSnapshot<SectionType, User>()
@@ -40,7 +40,7 @@ class UserListViewController: UIViewController {
             dataSource.apply(snapshot, animatingDifferences: true)
         }
     }
-    private var canFetchMore: Bool = false
+    private var canFetchMore = false
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -92,7 +92,7 @@ class UserListViewController: UIViewController {
             .drive(onNext: { [weak self] cell, indexPath in
                 guard let strongSelf = self else { return }
                 
-                if strongSelf.canFetchMore && indexPath.row >= (strongSelf.userList.count - 2) {
+                if strongSelf.canFetchMore, indexPath.row >= (strongSelf.userList.count - 2) {
                     // 次ページデータ取得
                     strongSelf.viewModelInput?.fetchMore()
                 }

--- a/FluxGithubApp/FluxGithubApp/Views/UserList/UserListViewController.swift
+++ b/FluxGithubApp/FluxGithubApp/Views/UserList/UserListViewController.swift
@@ -25,7 +25,7 @@ class UserListViewController: UIViewController {
     private let indicatorView = UIActivityIndicatorView(style: .medium)
     private lazy var dataSource: UITableViewDiffableDataSource<SectionType, User> = {
         let dataSource = UITableViewDiffableDataSource<SectionType, User>(tableView: tableView) { tableView, indexPath, user in
-            let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath) as! UserListTableViewCell
+            let cell = tableView.dequeueReusableCell(withIdentifier: UserListTableViewCell.className, for: indexPath) as! UserListTableViewCell
             cell.configure(user: user)
             return cell
         }
@@ -50,7 +50,7 @@ class UserListViewController: UIViewController {
         navigationItem.largeTitleDisplayMode = .always
         
         // セル登録
-        tableView.register(UINib.init(nibName: "UserListTableViewCell", bundle: nil), forCellReuseIdentifier: "Cell")
+        tableView.register(UINib.init(nibName: UserListTableViewCell.className, bundle: nil), forCellReuseIdentifier: UserListTableViewCell.className)
         
         // tableViewの設定
         tableView.dataSource = dataSource
@@ -78,6 +78,11 @@ class UserListViewController: UIViewController {
                 // TODO: ユーザー詳細ページへ遷移する処理を実装
                 owner.tableView.deselectRow(at: indexPath, animated: true)
                 print(indexPath)
+                
+                let user = owner.userList[indexPath.row]
+                let viewController = UserDetailViewController.instantiate()
+                viewController.username = user.name
+                owner.navigationController?.pushViewController(viewController, animated: true)
             })
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
## 概要

ユーザーの詳細画面として
- ユーザーの詳細情報
- ユーザーに紐づくリポジトリ一覧（Forkリポジトリは除く）
を表示する実装を行いました。

リポジトリCellをタップするとWebViewでリポジトリのURLを表示する実装も含めています。

※  DiffableDataSourceを使用した構成にしたかったが、時間と理解度の都合上使用せずUITableViewDataSourceを使用する構成にしています。（今後切り替える予定）