### PR TITLE
Routerを追加

### DIFF
--- a/FluxGithubApp/FluxGithubApp.xcodeproj/project.pbxproj
+++ b/FluxGithubApp/FluxGithubApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		086D676228884F85003C0F4E /* Transitioner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086D676128884F85003C0F4E /* Transitioner.swift */; };
 		192373CA28117373004BF245 /* UserListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192373C828117373004BF245 /* UserListTableViewCell.swift */; };
 		192373CB28117373004BF245 /* UserListTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 192373C928117373004BF245 /* UserListTableViewCell.xib */; };
 		192373CE28117855004BF245 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 192373CD28117855004BF245 /* Kingfisher */; };
@@ -81,6 +82,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		086D676128884F85003C0F4E /* Transitioner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transitioner.swift; sourceTree = "<group>"; };
 		192373C828117373004BF245 /* UserListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserListTableViewCell.swift; sourceTree = "<group>"; };
 		192373C928117373004BF245 /* UserListTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UserListTableViewCell.xib; sourceTree = "<group>"; };
 		192635D32814646300129705 /* UserDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetail.swift; sourceTree = "<group>"; };
@@ -166,6 +168,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		086D676028884F52003C0F4E /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				086D676128884F85003C0F4E /* Transitioner.swift */,
+			);
+			path = Protocols;
+			sourceTree = "<group>";
+		};
 		194A5617280DBA2D003E8EBB = {
 			isa = PBXGroup;
 			children = (
@@ -361,6 +371,7 @@
 		1975F35F2815436A007C96F4 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				086D676028884F52003C0F4E /* Protocols */,
 				1975F36028154370007C96F4 /* Extentions */,
 			);
 			path = Common;
@@ -557,6 +568,7 @@
 				194A568B2811487C003E8EBB /* User.swift in Sources */,
 				1991207C281599BD004B3AA5 /* Repos.swift in Sources */,
 				194A568928107B19003E8EBB /* UserListActionCreator.swift in Sources */,
+				086D676228884F85003C0F4E /* Transitioner.swift in Sources */,
 				1991207F2815A9F7004B3AA5 /* UserReposTableViewCell.swift in Sources */,
 				194A5686281079FA003E8EBB /* UserListViewModel.swift in Sources */,
 				192635D42814646300129705 /* UserDetail.swift in Sources */,

--- a/FluxGithubApp/FluxGithubApp.xcodeproj/project.pbxproj
+++ b/FluxGithubApp/FluxGithubApp.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		086D676228884F85003C0F4E /* Transitioner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086D676128884F85003C0F4E /* Transitioner.swift */; };
 		086D67642889930B003C0F4E /* UserListRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086D67632889930B003C0F4E /* UserListRouter.swift */; };
+		086D6766288BF41D003C0F4E /* UserDetailRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086D6765288BF41D003C0F4E /* UserDetailRouter.swift */; };
+		086D676A288BF587003C0F4E /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086D6769288BF587003C0F4E /* Router.swift */; };
 		192373CA28117373004BF245 /* UserListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192373C828117373004BF245 /* UserListTableViewCell.swift */; };
 		192373CB28117373004BF245 /* UserListTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 192373C928117373004BF245 /* UserListTableViewCell.xib */; };
 		192373CE28117855004BF245 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 192373CD28117855004BF245 /* Kingfisher */; };
@@ -85,6 +87,8 @@
 /* Begin PBXFileReference section */
 		086D676128884F85003C0F4E /* Transitioner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transitioner.swift; sourceTree = "<group>"; };
 		086D67632889930B003C0F4E /* UserListRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserListRouter.swift; sourceTree = "<group>"; };
+		086D6765288BF41D003C0F4E /* UserDetailRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetailRouter.swift; sourceTree = "<group>"; };
+		086D6769288BF587003C0F4E /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		192373C828117373004BF245 /* UserListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserListTableViewCell.swift; sourceTree = "<group>"; };
 		192373C928117373004BF245 /* UserListTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UserListTableViewCell.xib; sourceTree = "<group>"; };
 		192635D32814646300129705 /* UserDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetail.swift; sourceTree = "<group>"; };
@@ -178,6 +182,24 @@
 			path = Protocols;
 			sourceTree = "<group>";
 		};
+		086D6767288BF556003C0F4E /* Router */ = {
+			isa = PBXGroup;
+			children = (
+				086D6768288BF571003C0F4E /* Core */,
+				086D67632889930B003C0F4E /* UserListRouter.swift */,
+				086D6765288BF41D003C0F4E /* UserDetailRouter.swift */,
+			);
+			path = Router;
+			sourceTree = "<group>";
+		};
+		086D6768288BF571003C0F4E /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				086D6769288BF587003C0F4E /* Router.swift */,
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
 		194A5617280DBA2D003E8EBB = {
 			isa = PBXGroup;
 			children = (
@@ -207,6 +229,7 @@
 				194A5655280DC12C003E8EBB /* Flux */,
 				194A565D280DC2CD003E8EBB /* ViewModels */,
 				194A5657280DC195003E8EBB /* Models */,
+				086D6767288BF556003C0F4E /* Router */,
 				194A5656280DC152003E8EBB /* Views */,
 				194A5676280F06E3003E8EBB /* DI */,
 				194A5623280DBA2D003E8EBB /* AppDelegate.swift */,
@@ -307,7 +330,6 @@
 		194A567B280F131D003E8EBB /* UserList */ = {
 			isa = PBXGroup;
 			children = (
-				086D67632889930B003C0F4E /* UserListRouter.swift */,
 				194A567C280F1346003E8EBB /* UserList.storyboard */,
 				194A567E280F1464003E8EBB /* UserListViewController.swift */,
 				192373C828117373004BF245 /* UserListTableViewCell.swift */,
@@ -548,6 +570,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				086D676A288BF587003C0F4E /* Router.swift in Sources */,
 				1991207A2815999C004B3AA5 /* FetchReposListRequest.swift in Sources */,
 				192373CA28117373004BF245 /* UserListTableViewCell.swift in Sources */,
 				194A569228114D15003E8EBB /* UserListAction.swift in Sources */,
@@ -576,6 +599,7 @@
 				1991207F2815A9F7004B3AA5 /* UserReposTableViewCell.swift in Sources */,
 				194A5686281079FA003E8EBB /* UserListViewModel.swift in Sources */,
 				192635D42814646300129705 /* UserDetail.swift in Sources */,
+				086D6766288BF41D003C0F4E /* UserDetailRouter.swift in Sources */,
 				1975F37028154874007C96F4 /* UserDetailState.swift in Sources */,
 				1975F3672815462B007C96F4 /* UserDetailTableViewCell.swift in Sources */,
 				194A5666280DCE6D003E8EBB /* Dispatcher.swift in Sources */,

--- a/FluxGithubApp/FluxGithubApp.xcodeproj/project.pbxproj
+++ b/FluxGithubApp/FluxGithubApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		086D676228884F85003C0F4E /* Transitioner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086D676128884F85003C0F4E /* Transitioner.swift */; };
+		086D67642889930B003C0F4E /* UserListRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086D67632889930B003C0F4E /* UserListRouter.swift */; };
 		192373CA28117373004BF245 /* UserListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192373C828117373004BF245 /* UserListTableViewCell.swift */; };
 		192373CB28117373004BF245 /* UserListTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 192373C928117373004BF245 /* UserListTableViewCell.xib */; };
 		192373CE28117855004BF245 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 192373CD28117855004BF245 /* Kingfisher */; };
@@ -83,6 +84,7 @@
 
 /* Begin PBXFileReference section */
 		086D676128884F85003C0F4E /* Transitioner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transitioner.swift; sourceTree = "<group>"; };
+		086D67632889930B003C0F4E /* UserListRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserListRouter.swift; sourceTree = "<group>"; };
 		192373C828117373004BF245 /* UserListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserListTableViewCell.swift; sourceTree = "<group>"; };
 		192373C928117373004BF245 /* UserListTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UserListTableViewCell.xib; sourceTree = "<group>"; };
 		192635D32814646300129705 /* UserDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetail.swift; sourceTree = "<group>"; };
@@ -305,6 +307,7 @@
 		194A567B280F131D003E8EBB /* UserList */ = {
 			isa = PBXGroup;
 			children = (
+				086D67632889930B003C0F4E /* UserListRouter.swift */,
 				194A567C280F1346003E8EBB /* UserList.storyboard */,
 				194A567E280F1464003E8EBB /* UserListViewController.swift */,
 				192373C828117373004BF245 /* UserListTableViewCell.swift */,
@@ -554,6 +557,7 @@
 				1975F35628147519007C96F4 /* FetchUserListRequest.swift in Sources */,
 				199120832815E2BB004B3AA5 /* RepositoryDetailViewController.swift in Sources */,
 				194A567F280F1464003E8EBB /* UserListViewController.swift in Sources */,
+				086D67642889930B003C0F4E /* UserListRouter.swift in Sources */,
 				194A5668280DCEF9003E8EBB /* Action.swift in Sources */,
 				1975F3622815438B007C96F4 /* ViewController+Extention.swift in Sources */,
 				1975F35828147596007C96F4 /* FetchUserDetailRequest.swift in Sources */,

--- a/FluxGithubApp/FluxGithubApp/Common/Extentions/ViewController+Extention.swift
+++ b/FluxGithubApp/FluxGithubApp/Common/Extentions/ViewController+Extention.swift
@@ -19,3 +19,5 @@ extension StoryBoardHelperProtocol where Self: UIViewController {
 }
 
 extension UIViewController: StoryBoardHelperProtocol {}
+
+extension UIViewController: Transitioner {}

--- a/FluxGithubApp/FluxGithubApp/Common/Protocols/Transitioner.swift
+++ b/FluxGithubApp/FluxGithubApp/Common/Protocols/Transitioner.swift
@@ -1,0 +1,60 @@
+//
+//  Transitioner.swift
+//  FluxGithubApp
+//
+//  Created by 高橋志昂 on 2022/07/20.
+//
+
+import Foundation
+import UIKit
+
+protocol Transitioner where Self: UIViewController {
+    func pushViewController(_ viewController: UIViewController, animated: Bool)
+    func popViewController(animated: Bool)
+    func popToRootViewController(animated: Bool)
+    func popToViewController(_ viewController: UIViewController, animated: Bool)
+    func present(viewController: UIViewController, animated: Bool, completion: (() -> ())?)
+    func dismiss(animated: Bool)
+}
+
+extension Transitioner {
+    func pushViewController(_ viewController: UIViewController, animated: Bool) {
+        guard let nc = navigationController else {
+            assertionFailure("UINavigationControllerが見つからないため無効")
+            return
+        }
+        nc.pushViewController(viewController, animated: animated)
+    }
+    
+    func popViewController(animated: Bool) {
+        guard let nc = navigationController else {
+            assertionFailure("UINavigationControllerが見つからないため無効")
+            return
+        }
+        nc.popViewController(animated: animated)
+    }
+    
+    func popToRootViewController(animated: Bool) {
+        guard let nc = navigationController else {
+            assertionFailure("UINavigationControllerが見つからないため無効")
+            return
+        }
+        nc.popToRootViewController(animated: animated)
+    }
+    
+    func popToViewController(_ viewController: UIViewController, animated: Bool) {
+        guard let nc = navigationController else {
+            assertionFailure("UINavigationControllerが見つからないため無効")
+            return
+        }
+        nc.popToViewController(viewController, animated: animated)
+    }
+    
+    func present(viewController: UIViewController, animated: Bool, completion: (() -> ())? = nil) {
+        present(viewController: viewController, animated: animated, completion: completion)
+    }
+    
+    func dismiss(animated: Bool) {
+        dismiss(animated: animated)
+    }
+}

--- a/FluxGithubApp/FluxGithubApp/Common/Protocols/Transitioner.swift
+++ b/FluxGithubApp/FluxGithubApp/Common/Protocols/Transitioner.swift
@@ -13,7 +13,7 @@ protocol Transitioner where Self: UIViewController {
     func popViewController(animated: Bool)
     func popToRootViewController(animated: Bool)
     func popToViewController(_ viewController: UIViewController, animated: Bool)
-    func present(viewController: UIViewController, animated: Bool, completion: (() -> ())?)
+    func present(_ viewController: UIViewController, animated: Bool, completion: (() -> Void)?)
     func dismiss(animated: Bool)
 }
 
@@ -50,8 +50,8 @@ extension Transitioner {
         nc.popToViewController(viewController, animated: animated)
     }
     
-    func present(viewController: UIViewController, animated: Bool, completion: (() -> ())? = nil) {
-        present(viewController: viewController, animated: animated, completion: completion)
+    func present(_ viewController: UIViewController, animated: Bool, completion: (() -> Void)? = nil) {
+        present(viewController, animated: animated, completion: completion)
     }
     
     func dismiss(animated: Bool) {

--- a/FluxGithubApp/FluxGithubApp/DI/SwinjectStoryboard.swift
+++ b/FluxGithubApp/FluxGithubApp/DI/SwinjectStoryboard.swift
@@ -34,7 +34,7 @@ extension SwinjectStoryboard {
         
         // Store
         defaultContainer.register(UserListStore.self) { r in
-            UserListStore(r.resolve(Dispatcher.self)!)
+            UserListStoreImpl(r.resolve(Dispatcher.self)!)
         }
         .inObjectScope(.container)
         
@@ -45,7 +45,7 @@ extension SwinjectStoryboard {
         
         // ActionCreator
         defaultContainer.register(UserListActionCreator.self) { r in
-            UserListActionCreator(
+            UserListActionCreatorImpl(
                 r.resolve(Dispatcher.self)!,
                 userRepository: r.resolve(UserRepository.self)!
             )

--- a/FluxGithubApp/FluxGithubApp/DI/SwinjectStoryboard.swift
+++ b/FluxGithubApp/FluxGithubApp/DI/SwinjectStoryboard.swift
@@ -78,8 +78,10 @@ extension SwinjectStoryboard {
         
         // ViewController
         defaultContainer.storyboardInitCompleted(UserListViewController.self) { r, c in
-            c.viewModelInput = r.resolve(UserListViewModel.self)
-            c.viewModelOutput = r.resolve(UserListViewModel.self)
+            let viewModel = r.resolve(UserListViewModel.self)
+            viewModel?.injectRouter(UserListRouterImpl(view: c))
+            c.viewModelInput = viewModel
+            c.viewModelOutput = viewModel
         }
         
         defaultContainer.storyboardInitCompleted(UserDetailViewController.self) { r, c in

--- a/FluxGithubApp/FluxGithubApp/DI/SwinjectStoryboard.swift
+++ b/FluxGithubApp/FluxGithubApp/DI/SwinjectStoryboard.swift
@@ -85,8 +85,10 @@ extension SwinjectStoryboard {
         }
         
         defaultContainer.storyboardInitCompleted(UserDetailViewController.self) { r, c in
-            c.viewModelInput = r.resolve(UserDetailViewModel.self)
-            c.viewModelOutput = r.resolve(UserDetailViewModel.self)
+            let viewModel = r.resolve(UserDetailViewModel.self)
+            viewModel?.injectRouter(UserDetailRouterImpl(view: c))
+            c.viewModelInput = viewModel
+            c.viewModelOutput = viewModel
         }
     }
 }

--- a/FluxGithubApp/FluxGithubApp/DI/SwinjectStoryboard.swift
+++ b/FluxGithubApp/FluxGithubApp/DI/SwinjectStoryboard.swift
@@ -39,7 +39,7 @@ extension SwinjectStoryboard {
         .inObjectScope(.container)
         
         defaultContainer.register(UserDetailStore.self) { r in
-            UserDetailStore(r.resolve(Dispatcher.self)!)
+            UserDetailStoreImpl(r.resolve(Dispatcher.self)!)
         }
         .inObjectScope(.container)
         
@@ -53,7 +53,7 @@ extension SwinjectStoryboard {
         .inObjectScope(.container)
         
         defaultContainer.register(UserDetailActionCreator.self) { r in
-            UserDetailActionCreator(
+            UserDetailActionCreatorImpl(
                 r.resolve(Dispatcher.self)!,
                 userRepository: r.resolve(UserRepository.self)!,
                 reposRepository: r.resolve(ReposRepository.self)!

--- a/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailActionCreator.swift
+++ b/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailActionCreator.swift
@@ -7,7 +7,13 @@
 
 import RxSwift
 
-final class UserDetailActionCreator: ActionCreator {
+protocol UserDetailActionCreator {
+    func fetchUserDetail(username: String)
+    func firstFetchUserRepositories(username: String, perPage: Int)
+    func moreFetchUserRepositories(username: String, page: Int, perPage: Int)
+}
+
+final class UserDetailActionCreatorImpl: ActionCreator, UserDetailActionCreator {
     private var userRepository: UserRepository
     private var reposRepository: ReposRepository
     

--- a/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailStore.swift
+++ b/FluxGithubApp/FluxGithubApp/Flux/UserDetail/UserDetailStore.swift
@@ -8,7 +8,12 @@
 import RxSwift
 import RxRelay
 
-final class UserDetailStore: Store {
+protocol UserDetailStore {
+    var state: UserDetailState { get }
+    var stateObservable: Observable<UserDetailState> { get }
+}
+
+final class UserDetailStoreImpl: Store, UserDetailStore {
     
     private let _state = BehaviorRelay<UserDetailState>(
         value: UserDetailState(
@@ -42,7 +47,7 @@ final class UserDetailStore: Store {
     }
 }
 
-extension UserDetailStore {
+extension UserDetailStoreImpl {
     private func onAction(action: UserDetailAction) {
         switch action {
         case .userDetailFetched(let user):

--- a/FluxGithubApp/FluxGithubApp/Flux/UserList/UserListActionCreator.swift
+++ b/FluxGithubApp/FluxGithubApp/Flux/UserList/UserListActionCreator.swift
@@ -7,7 +7,12 @@
 
 import RxSwift
 
-final class UserListActionCreator: ActionCreator {
+protocol UserListActionCreator {
+    func firstFetchUserList(perPage: Int)
+    func moreFetchUserList(since: Int, perPage: Int)
+}
+
+final class UserListActionCreatorImpl: ActionCreator, UserListActionCreator {
     private var userRepository: UserRepository
     
     required init(_ dispatcher: Dispatcher, userRepository: UserRepository) {

--- a/FluxGithubApp/FluxGithubApp/Flux/UserList/UserListStore.swift
+++ b/FluxGithubApp/FluxGithubApp/Flux/UserList/UserListStore.swift
@@ -8,7 +8,12 @@
 import RxSwift
 import RxRelay
 
-final class UserListStore: Store {
+protocol UserListStore {
+    var state: UserListState { get }
+    var stateObservable: Observable<UserListState> { get }
+}
+
+final class UserListStoreImpl: Store, UserListStore {
     
     private let _state = BehaviorRelay<UserListState>(
         value: UserListState(
@@ -40,7 +45,7 @@ final class UserListStore: Store {
     }
 }
 
-extension UserListStore {
+extension UserListStoreImpl {
     private func onAction(action: UserListAction) {
         switch action {
         case .firstFetched(let isDataEnded, let users):

--- a/FluxGithubApp/FluxGithubApp/Router/Core/Router.swift
+++ b/FluxGithubApp/FluxGithubApp/Router/Core/Router.swift
@@ -1,0 +1,14 @@
+//
+//  Router.swift
+//  FluxGithubApp
+//
+//  Created by 高橋志昂 on 2022/07/23.
+//
+
+class Router {
+    private(set) weak var view: Transitioner!
+    
+    init(view: Transitioner) {
+        self.view = view
+    }
+}

--- a/FluxGithubApp/FluxGithubApp/Router/UserDetailRouter.swift
+++ b/FluxGithubApp/FluxGithubApp/Router/UserDetailRouter.swift
@@ -1,0 +1,20 @@
+//
+//  UserDetailRouter.swift
+//  FluxGithubApp
+//
+//  Created by 高橋志昂 on 2022/07/23.
+//
+
+import Foundation
+
+protocol UserDetailRouter {
+    func transitionToRepositoryDetail(url: URL)
+}
+
+final class UserDetailRouterImpl: Router, UserDetailRouter {
+    func transitionToRepositoryDetail(url: URL) {
+        let viewController = RepositoryDetailViewController()
+        viewController.url = url
+        view.pushViewController(viewController, animated: true)
+    }
+}

--- a/FluxGithubApp/FluxGithubApp/Router/UserListRouter.swift
+++ b/FluxGithubApp/FluxGithubApp/Router/UserListRouter.swift
@@ -9,14 +9,7 @@ protocol UserListRouter {
     func transitionToUserDetail(username: String)
 }
 
-final class UserListRouterImpl: UserListRouter {
-    
-    private weak var view: Transitioner!
-    
-    init(view: Transitioner) {
-        self.view = view
-    }
-    
+final class UserListRouterImpl: Router, UserListRouter {
     func transitionToUserDetail(username: String) {
         let viewController = UserDetailViewController.instantiate()
         viewController.username = username

--- a/FluxGithubApp/FluxGithubApp/ViewModels/UserListViewModel.swift
+++ b/FluxGithubApp/FluxGithubApp/ViewModels/UserListViewModel.swift
@@ -23,8 +23,7 @@ protocol UserListViewModelOutput {
     var apiError: Observable<Error?> { get }
 }
 
-class UserListViewModel: UserListViewModelOutput {
-    
+final class UserListViewModel: UserListViewModelOutput {
     private let PER_PAGE = 20
     
     private let actionCreator: UserListActionCreator

--- a/FluxGithubApp/FluxGithubApp/ViewModels/UserListViewModel.swift
+++ b/FluxGithubApp/FluxGithubApp/ViewModels/UserListViewModel.swift
@@ -5,11 +5,13 @@
 //  Created by Takahashi Shiko on 2022/04/21.
 //
 
+import Foundation
 import RxSwift
 
 protocol UserListViewModelInput {
     func fetchUserList()
     func fetchMore()
+    func didSelectRow(at indexPath: IndexPath)
 }
 
 protocol UserListViewModelOutput {
@@ -21,11 +23,13 @@ protocol UserListViewModelOutput {
     var apiError: Observable<Error?> { get }
 }
 
-class UserListViewModel: UserListViewModelInput, UserListViewModelOutput {
+class UserListViewModel: UserListViewModelOutput {
+    
     private let PER_PAGE = 20
     
     private let actionCreator: UserListActionCreator
     private let store: UserListStore
+    private var router: UserListRouter?
     
     var users: Observable<[User]>
     var canFetchMore: Observable<Bool>
@@ -34,10 +38,12 @@ class UserListViewModel: UserListViewModelInput, UserListViewModelOutput {
     var isMoreLoading: Observable<Bool>
     var apiError: Observable<Error?>
     
-    init(actionCreator: UserListActionCreator, store: UserListStore) {
+    init(
+        actionCreator: UserListActionCreator,
+        store: UserListStore
+    ) {
         self.actionCreator = actionCreator
         self.store = store
-        
         
         self.users = store.stateObservable.map { state in
             state.users
@@ -70,6 +76,12 @@ class UserListViewModel: UserListViewModelInput, UserListViewModelOutput {
         .share()
     }
     
+    func injectRouter(_ router: UserListRouter) {
+        self.router = router
+    }
+}
+
+extension UserListViewModel: UserListViewModelInput {
     func fetchUserList() {
         actionCreator.firstFetchUserList(perPage: PER_PAGE)
     }
@@ -78,5 +90,10 @@ class UserListViewModel: UserListViewModelInput, UserListViewModelOutput {
         guard let since = store.state.users.last?.id else { return }
         
         actionCreator.moreFetchUserList(since: since, perPage: PER_PAGE)
+    }
+    
+    func didSelectRow(at indexPath: IndexPath) {
+        let user = store.state.users[indexPath.row]
+        router?.transitionToUserDetail(username: user.name)
     }
 }

--- a/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetailViewController.swift
+++ b/FluxGithubApp/FluxGithubApp/Views/UserDetail/UserDetailViewController.swift
@@ -45,19 +45,29 @@ class UserDetailViewController: UIViewController {
         
         title = username
         
-        // セル登録
-        tableView.register(UINib.init(nibName: UserDetailTableViewCell.className, bundle: nil), forCellReuseIdentifier: UserDetailTableViewCell.className)
-        tableView.register(UINib.init(nibName: UserReposTableViewCell.className, bundle: nil), forCellReuseIdentifier: UserReposTableViewCell.className)
-        
-        // tableViewの設定
-        tableView.estimatedRowHeight = 80
-        tableView.rowHeight = UITableView.automaticDimension
+        setUpTableView()
         
         viewModelInput?.fetchUserDetail(username: username)
         viewModelInput?.fetchReposList(username: username)
         
         setTableViewSubscribes()
         setViewModelSubscribes()
+    }
+    
+    private func setUpTableView() {
+        // セル登録
+        tableView.register(
+            UINib(nibName: UserDetailTableViewCell.className, bundle: nil),
+            forCellReuseIdentifier: UserDetailTableViewCell.className
+        )
+        tableView.register(
+            UINib(nibName: UserReposTableViewCell.className, bundle: nil),
+            forCellReuseIdentifier: UserReposTableViewCell.className
+        )
+        
+        // tableViewの設定
+        tableView.estimatedRowHeight = 80
+        tableView.rowHeight = UITableView.automaticDimension
     }
     
     private func setTableViewSubscribes() {

--- a/FluxGithubApp/FluxGithubApp/Views/UserList/UserListRouter.swift
+++ b/FluxGithubApp/FluxGithubApp/Views/UserList/UserListRouter.swift
@@ -1,0 +1,25 @@
+//
+//  UserListRouter.swift
+//  FluxGithubApp
+//
+//  Created by 高橋志昂 on 2022/07/21.
+//
+
+protocol UserListRouter {
+    func transitionToUserDetail(username: String)
+}
+
+final class UserListRouterImpl: UserListRouter {
+    
+    private weak var view: Transitioner!
+    
+    init(view: Transitioner) {
+        self.view = view
+    }
+    
+    func transitionToUserDetail(username: String) {
+        let viewController = UserDetailViewController.instantiate()
+        viewController.username = username
+        view.pushViewController(viewController, animated: true)
+    }
+}

--- a/FluxGithubApp/FluxGithubApp/Views/UserList/UserListViewController.swift
+++ b/FluxGithubApp/FluxGithubApp/Views/UserList/UserListViewController.swift
@@ -15,7 +15,7 @@ class UserListViewController: UIViewController {
         case userList
     }
 
-    @IBOutlet weak var tableView: UITableView!
+    @IBOutlet private weak var tableView: UITableView!
     
     var viewModelInput: UserListViewModelInput?
     var viewModelOutput: UserListViewModelOutput?
@@ -45,17 +45,8 @@ class UserListViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        title = "User List"
-        navigationController?.navigationBar.prefersLargeTitles = true
-        navigationItem.largeTitleDisplayMode = .always
-        
-        // セル登録
-        tableView.register(UINib.init(nibName: UserListTableViewCell.className, bundle: nil), forCellReuseIdentifier: UserListTableViewCell.className)
-        
-        // tableViewの設定
-        tableView.dataSource = dataSource
-        tableView.estimatedRowHeight = 80
-        tableView.rowHeight = UITableView.automaticDimension
+        setUpNavigationController()
+        setUpTableView()
         
         viewModelInput?.fetchUserList()
         
@@ -70,17 +61,32 @@ class UserListViewController: UIViewController {
         indicatorView.frame = CGRect(x: 0, y: 0, width: self.view.frame.size.width, height: 40)
     }
     
+    private func setUpNavigationController() {
+        title = "User List"
+        navigationController?.navigationBar.prefersLargeTitles = true
+        navigationItem.largeTitleDisplayMode = .always
+    }
+    
+    private func setUpTableView() {
+        // セル登録
+        tableView.register(
+            UINib.init(nibName: UserListTableViewCell.className, bundle: nil),
+            forCellReuseIdentifier: UserListTableViewCell.className
+        )
+        
+        // tableViewの設定
+        tableView.dataSource = dataSource
+        tableView.estimatedRowHeight = 80
+        tableView.rowHeight = UITableView.automaticDimension
+    }
+    
     private func setTableViewSubscribes() {
         // タップアクション
         tableView.rx.itemSelected
             .asSignal()
             .emit(with: self, onNext: { owner, indexPath in
                 owner.tableView.deselectRow(at: indexPath, animated: true)
-                
-                let user = owner.userList[indexPath.row]
-                let viewController = UserDetailViewController.instantiate()
-                viewController.username = user.name
-                owner.navigationController?.pushViewController(viewController, animated: true)
+                owner.viewModelInput?.didSelectRow(at: indexPath)
             })
             .disposed(by: disposeBag)
         

--- a/FluxGithubApp/FluxGithubApp/Views/UserList/UserListViewController.swift
+++ b/FluxGithubApp/FluxGithubApp/Views/UserList/UserListViewController.swift
@@ -70,7 +70,7 @@ class UserListViewController: UIViewController {
     private func setUpTableView() {
         // セル登録
         tableView.register(
-            UINib.init(nibName: UserListTableViewCell.className, bundle: nil),
+            UINib(nibName: UserListTableViewCell.className, bundle: nil),
             forCellReuseIdentifier: UserListTableViewCell.className
         )
         


### PR DESCRIPTION
## 概要
画面遷移の責務をRouterにまとめる対応をいたしました。

- Transitioner: UIViewControllerの画面遷移ロジックを抽象化（UIViewControllerから画面遷移の責務を引き剥がす目的）
- 各Router: 画面ごとの画面遷移を担当する。Transitionerのprotocol extentionで実装されている画面遷移処理を呼び出す。

※ また、他のモジュールに関する記述に関してのリファクタリングも含めています。